### PR TITLE
mainArtists dictionary may be empty, use 'unknown' for that case

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -84,7 +84,11 @@ if __name__ == "__main__":
             fd, tmpFileName = tempfile.mkstemp()
 
             trackUrl = track['stems']['full']['lqMp3Url']
-            trackAuthor = track['creatives']['mainArtists'][0]['name']
+            if len( track['creatives']['mainArtists'] ) == 0:
+                trackAuthor = 'Unknown'
+            else:
+                trackAuthor = track['creatives']['mainArtists'][0]['name']
+                
             trackName = removeUnsupportedSymbols(track['title'])           
             finalFileName = '{}/{}/{} - {}.mp3'.format(os.getcwd(), folderName, trackAuthor, trackName)
 


### PR DESCRIPTION
Field 'mainArtists' not always contains data, so we need to check whether there's some info to use. If nothing's here - use a placeholder.

Attaching the case:

```
 {'id': 28719, 'title': 'Phone Booths (Sting)', 'added': '2014-04-07T08:59:08', 'creatives': {'composers': [], 'mainArtists': [], 'featuredArtists': [], 'producers': []}, 'length': 29, 'bpm': 92, 'isSfx': True, 'hasVocals': False, 'hidden': False, 'publicSlug': 'PESWtyIOwu', 'genres': [{'tag': 'Musical Stings', 'fatherTag': 'Musical', 'slug': 'musical-stings'}], 'moods': [{'tag': 'Sound Effects', 'fatherTag': 'Sound Fx', 'slug': 'sound-effects'}], 'energyLevel': 'medium', 'stems': {'full': {'stemType': 'full', 's3TrackId': 99863, 'lqMp3Url': 'https://dkihjuum4jcjr.cloudfront.net/ES_ITUNES/Phone%20Booths%20(Sting)/ES_Phone%20Booths%20(Sting).mp3'}}, 'oldTitle': None, 'seriesId': None, 'metadataTags': ['rnb', 'beats', 'mysterious', 'scene transition'], 'isExplicit': False, 'isCommercialRelease': False, 'coverArt': {'baseUrl': 'https://cdn.epidemicsound.com/curation-assets/commercial-release-cover-images/default/', 'sizes': {'XS': '128x128.jpg', 'S': '300x300.jpg', 'M': '600x600.jpg', 'L': '1050x1050.jpg'}}, 'releaseDate': None}:
Traceback (most recent call last):
  File "/Volumes/MIKE'S HDD/Assets/Epidemic-Sound-Albums-Downloader-main/__init__.py", line 88, in <module>
    trackAuthor = track['creatives']['mainArtists'][0]['name']
IndexError: list index out of range
```
